### PR TITLE
Fix typos and improve content consistency across multiple pages

### DIFF
--- a/src/components/card/Card.astro
+++ b/src/components/card/Card.astro
@@ -22,7 +22,7 @@ const { href, title, body, isExternalLink } = Astro.props as Props;
     <h2
       class="flex items-start justify-between text-2xl capitalize text-dodger-blue dark:text-melrose"
     >
-      <sapn>{title}</sapn>
+      <span>{title}</span>
       <span class="mt-2 ml-1 block w-4 flex-shrink-0 md:m-0"
         >{isExternalLink ? <External /> : <ArrowRight />}</span
       >

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -13,7 +13,7 @@ import { Heading1 } from '~typography/Heading1';
       I've been a computer geek and a techie my entire life. However, my
       professional Internet and startup journey started somewhere in late 2009
       when during my University studies I was the webmaster for the Israeli
-      Museam for Comics. Not long after that, I found myself doing SEO,
+      Museum for Comics. Not long after that, I found myself doing SEO,
       Marketing, Ecommerce, consultancy, and oddjob dev work, sometimes as a
       freelancer others as an employee.
     </p>
@@ -31,7 +31,7 @@ import { Heading1 } from '~typography/Heading1';
       >
     </p>
     <p>
-      I Also co-orginize the <ExternalLink
+      I also co-organize the <ExternalLink
         href="https://www.facebook.com/groups/next.js.israel"
         withIcon>"Next.js Israel Community"</ExternalLink
       > and <ExternalLink href="https://www.meetup.com/react-tlv/" withIcon

--- a/src/pages/appearances.astro
+++ b/src/pages/appearances.astro
@@ -120,7 +120,8 @@ const list: Array<Appearance> = [
   {
     where: 'Frontend Land',
     when: 'Aug 05 2021',
-    title: 'Webpack Module Federaion with Zack Jackson & Yoav Ganbar (English)',
+    title:
+      'Webpack Module Federation with Zack Jackson & Yoav Ganbar (English)',
     link: 'https://rss.com/podcasts/frontend-land/250321/',
   },
   {
@@ -139,10 +140,10 @@ const list: Array<Appearance> = [
 ---
 
 <BaseLayout
-  title="Appearences | hamatoyogi.dev"
-  description="Apperences, podcasts, interviews, and talks by Yoav Ganbar"
+  title="Appearances | hamatoyogi.dev"
+  description="Appearances, podcasts, interviews, and talks by Yoav Ganbar"
 >
-  <Heading1 extraClasses="mt-10 md:mt-32">Appearences</Heading1>
+  <Heading1 extraClasses="mt-10 md:mt-32">Appearances</Heading1>
   <ul role="list" class="ml-4 mt-10 list-disc space-y-4 md:mt-20">
     {
       list.map(({ where, when, title, link }) => (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,7 +14,7 @@ Astro.response.headers.set(
 
 <BaseLayout
   title="hamatoyogi's site"
-  description="Yoav Ganbar AKA HamatoYogi · Web Developer, FedBites podcast co-host, community orginizer. I love building products, shipping code, talking about it, and writing about it."
+  description="Yoav Ganbar AKA HamatoYogi · Web Developer, FedBites podcast co-host, community organizer. I love building products, shipping code, talking, and writing about it."
 >
   <figure
     class="w-20 h-20 mt-10 overflow-hidden border rounded-full border-lavender-gray"
@@ -32,7 +32,7 @@ Astro.response.headers.set(
   <h2 class="mt-4 text-2xl md:text-4xl">Web Developer</h2>
   <h3 class="mt-2 text-xl md:text-2xl">
     Trying to make the web a better place and help developers along the way.
-    FedBites podcast co-host, community orginizer. I love building products,
+    FedBites podcast co-host, community organizer. I love building products,
     shipping code, talking about it, and writing about it.
   </h3>
   <p class="flex flex-wrap items-center gap-3 mt-10 md:mt-14">


### PR DESCRIPTION
- Corrected "sapn" to "span" in Card.astro.
- Fixed "Museam" to "Museum" and "orginize" to "organize" in about.astro.
- Updated "Apperences" to "Appearances" in appearances.astro.
- Standardized "orginizer" to "organizer" in index.astro.

These changes enhance the clarity and professionalism of the text.