### PR TITLE
Update work experience: Claroty as current role

### DIFF
--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -7,14 +7,16 @@ import { Heading1 } from '~typography/Heading1';
 <BaseLayout title="Work | hamatoyogi.dev" description="Where I work">
   <Heading1 extraClasses="mt-10 md:mt-32">Work</Heading1>
   <p class="mt-10">
-    I am a partner at <ExternalLink href="https://reactive-dev.com"
-      >ReactiveDev</ExternalLink
-    >, a software development consultancy focusing on modern web technologies.
+    I am a Senior Software Engineer at <ExternalLink href="https://claroty.com"
+      >Claroty</ExternalLink
+    >, a cyber-physical systems security company.
   </p>
   <p class="mt-10">
     Previously, I helped build <ExternalLink href="https://jux.io"
       >Jux</ExternalLink
-    >.
+    >, and was a partner at <ExternalLink href="https://reactive-dev.com"
+      >ReactiveDev</ExternalLink
+    >, a software development consultancy focusing on modern web technologies.
   </p>
   <p class="mt-10">
     Beforehand, I was @ <ExternalLink href="https://builder.io"


### PR DESCRIPTION
## Summary
Updated the work experience section to reflect current employment status and reorganize professional history.

## Changes
- Changed current role from "partner at ReactiveDev" to "Senior Software Engineer at Claroty" (a cyber-physical systems security company)
- Reorganized previous experience section to list Jux first, followed by ReactiveDev partnership
- Updated the description of ReactiveDev to the "Previously" section for better chronological flow

## Details
The work page now accurately reflects the current employment at Claroty while maintaining a clear timeline of previous roles and experiences.

https://claude.ai/code/session_01V24MvD1Rz5YGK6TEtwvPsK